### PR TITLE
Add method BSON::OID::from_epoch

### DIFF
--- a/lib/BSON/OID.pm
+++ b/lib/BSON/OID.pm
@@ -10,6 +10,7 @@ our $VERSION = 'v0.999.6';
 
 use Carp;
 use Digest::MD5 'md5';
+use Scalar::Util 'looks_like_number';
 use Sys::Hostname;
 use threads::shared; # NOP if threads.pm not loaded
 
@@ -40,8 +41,9 @@ use namespace::clean -except => 'meta';
 
     #<<<
     sub _packed_oid {
+        my $time = defined $_[0] ? $_[0] : time;
         return pack(
-            'Na3na3', time, $_host, $$ % 0xFFFF,
+            'Na3na3', $time, $_host, $$ % 0xFFFF,
             substr( pack( 'N', do { lock($_inc); $_inc++; $_inc %= 0xFFFFFF }), 1, 3)
         );
     }
@@ -65,6 +67,23 @@ sub BUILD {
     croak "Invalid 'oid' field: OIDs must be 12 bytes"
       unless length( $self->oid ) == 12;
     return;
+}
+
+=method from_epoch
+
+Returns a new OID generated using the given epoch time (in seconds).
+
+=cut
+
+sub from_epoch {
+    my ($self, $epoch) = @_;
+
+    croak "argument to BSON::OID::from_epoch must be epoch seconds, not '$epoch'"
+      unless looks_like_number( $epoch );
+
+    $self->{oid} = _packed_oid(int($epoch));
+    delete $self->{_hex};
+    return $self;
 }
 
 =method hex
@@ -133,6 +152,7 @@ __END__
     use BSON::Types ':all';
 
     my $oid  = bson_oid();
+    my $oid  = bson_oid->from_epoch(1467543496);
 
     my $bytes = $oid->oid;
     my $hex   = $oid->hex;

--- a/lib/BSON/OID.pm
+++ b/lib/BSON/OID.pm
@@ -9,10 +9,17 @@ use version;
 our $VERSION = 'v0.999.6';
 
 use Carp;
+use Config;
 use Digest::MD5 'md5';
 use Scalar::Util 'looks_like_number';
 use Sys::Hostname;
 use threads::shared; # NOP if threads.pm not loaded
+
+use constant {
+    HAS_INT64 => $Config{use64bitint},
+    INT64_MAX => 9223372036854775807,
+    INT32_MAX => 2147483647,
+};
 
 use Moo;
 
@@ -47,6 +54,25 @@ use namespace::clean -except => 'meta';
             substr( pack( 'N', do { lock($_inc); $_inc++; $_inc %= 0xFFFFFF }), 1, 3)
         );
     }
+    sub _packed_oid_special {
+        my ($time, $fill) = @_;
+
+        croak "BSON::OID::from_epoch: second argument must be an interger"
+          unless looks_like_number( $fill );
+
+        # Zero-filled OID with custom time
+        if ($fill == 0) {
+            return pack('Na8', $time, "\0" x 8);
+        }
+
+        # Random OID with custom time
+        if (HAS_INT64) {
+           return pack( 'Nq', $time, (rand(INT64_MAX) + 1) );
+        }
+
+        sub randmax32 () { rand(INT32_MAX) + 1 }
+        return pack('N3', $time, randmax32, randmax32);
+    }
     #>>>
 
     # see if v1.x MongoDB::BSON can do OIDs for us
@@ -71,18 +97,52 @@ sub BUILD {
 
 =method from_epoch
 
-Returns a new OID generated using the given epoch time (in seconds).
+Returns a new OID generated using the given epoch time (in seconds) to be
+used in queries.
+
+B<Warning!> You should never insert documents with an OID generated with
+this method. It is unsafe because the uniqueness of the OID is no longer
+guaranteed.
+
+There are 3 ways to use this method:
+
+  my $oid = BSON::OID->from_epoch(1467545180);
+
+This generates a standard OID with given epoch. You should not use this
+form in newly written code. It is here for compatibility.
+
+  my $oid = BSON::OID->from_epoch(1467545180, 0);
+
+The additional C<0> at the end means you want a zero-ed OID. All the fields
+will be set to zero except the date. This is particularly useful when looking
+for documents by their insertion date: you can simply look for OIDs which are
+greater or lower than the one generated with this method.
+
+  my $oid = BSON::OID->from_epoch(1467545180, 1);
+
+Any value different from zero as a second argument means you want a randomized
+OID: the date field is set to the given epoch but the rest of the OID is just
+a 64 bit random number. This should be enough to avoid collisions in most cases.
 
 =cut
 
 sub from_epoch {
-    my ($self, $epoch) = @_;
+    my ($self, $epoch, $fill) = @_;
 
-    croak "argument to BSON::OID::from_epoch must be epoch seconds, not '$epoch'"
+    croak "BSON::OID::from_epoch expects an epoch in seconds, not '$epoch'"
       unless looks_like_number( $epoch );
 
-    $self->{oid} = _packed_oid(int($epoch));
-    delete $self->{_hex};
+    my $oid = defined $fill
+      ? _packed_oid_special($epoch, $fill)
+      : _packed_oid($epoch);
+
+    if (ref $self) {
+        $self->{oid} = $oid;
+    }
+    else {
+        $self = $self->new(oid => $oid);
+    }
+
     return $self;
 }
 

--- a/lib/BSON/ObjectId.pm
+++ b/lib/BSON/ObjectId.pm
@@ -20,7 +20,7 @@ sub new {
         $self->value( $value );
     }
     else {
-        $self->{oid} = $self->_packed_oid();
+        $self->{oid} = BSON::OID::_packed_oid();
     }
     return $self;
 }

--- a/t/mapping/oid.t
+++ b/t/mapping/oid.t
@@ -16,7 +16,7 @@ use TestUtils;
 use BSON qw/encode decode/;
 use BSON::Types ':all';
 
-my ( $bson, $expect, $hash );
+my ( $bson, $expect, $hash, $epoch );
 
 my $packed = BSON::OID::_generate_oid();
 my $hexoid = unpack( "H*", $packed );
@@ -39,6 +39,10 @@ $bson = $expect = encode( { A => bson_oid($packed) } );
 $hash = decode($bson);
 is( ref( $hash->{A} ), 'BSON::OID', "BSON::OID->BSON::OID" );
 is( "$hash->{A}",      $hexoid,     "value correct" );
+
+# BSON::OID from_epoch
+$epoch = 1467545180;
+is( bson_oid->from_epoch($epoch)->get_time, $epoch, "from_epoch roundtrip ok" );
 
 # BSON::ObjectId (deprecated) -> BSON::OID
 $hash = encode( { A => BSON::ObjectId->new($packed) } );

--- a/t/mapping/oid.t
+++ b/t/mapping/oid.t
@@ -16,18 +16,26 @@ use TestUtils;
 use BSON qw/encode decode/;
 use BSON::Types ':all';
 
-my ( $bson, $expect, $hash, $epoch );
+my ( $bson, $expect, $hash );
 
 my $packed = BSON::OID::_generate_oid();
 my $hexoid = unpack( "H*", $packed );
 
-# test constructor
+# test constructors
 is( length( bson_oid()->oid ), 12,      "empty bson_oid() generates new OID" );
+is( length( bson_oid()->from_epoch(time)->oid ), 12,
+    "from_epoch(time) generates new OID" );
+is( length( bson_oid()->from_epoch(time, 0)->oid ), 12,
+    "from_epoch(time, 0) generates new OID" );
+is( length( bson_oid()->from_epoch(time, 1)->oid ), 12,
+    "from_epoch(time, 1) generates new OID" );
 is( bson_oid($packed)->oid,    $packed, "bson_oid(\$packed) returns packed" );
 is( bson_oid($hexoid)->oid,    $packed, "bson_oid(\$hexoid) returns packed" );
 
 is( length( BSON::OID->new()->oid ), 12,
     "empty BSON::OID->new() generates new OID" );
+is( length( BSON::OID->from_epoch(time)->oid ), 12,
+    "empty BSON::OID->from_epoch(time) generates new OID" );
 is( BSON::OID->new(oid => $packed)->oid,
     $packed, "BSON::OID->new(\$packed) returns packed" );
 
@@ -41,8 +49,15 @@ is( ref( $hash->{A} ), 'BSON::OID', "BSON::OID->BSON::OID" );
 is( "$hash->{A}",      $hexoid,     "value correct" );
 
 # BSON::OID from_epoch
-$epoch = 1467545180;
-is( bson_oid->from_epoch($epoch)->get_time, $epoch, "from_epoch roundtrip ok" );
+my $epoch = 1467545180;
+my $packed_zero = pack('N3', $epoch, 0, 0);
+is( BSON::OID->from_epoch($epoch)->get_time, $epoch, "from_epoch roundtrip ok" );
+is( BSON::OID->from_epoch($epoch, 0)->oid, $packed_zero,
+    "from_epoch(time, 0) OID is correct" );
+is( BSON::OID->from_epoch($epoch, 1)->get_time, $epoch,
+    "from_epoch(time, 1) roundtrip ok" );
+is( bson_oid->from_epoch($epoch, 1)->get_time, $epoch,
+    "from_epoch(time, 1) roundtrip ok" );
 
 # BSON::ObjectId (deprecated) -> BSON::OID
 $hash = encode( { A => BSON::ObjectId->new($packed) } );


### PR DESCRIPTION
This method allows to create a new OID using a specific epoch time.
Mango users really need this feature because their application's
logic relies on it in some cases.