### PR TITLE
Add dt_type support for Mango::BSON::Time

### DIFF
--- a/lib/BSON.pm
+++ b/lib/BSON.pm
@@ -216,7 +216,7 @@ so is somewhat backwards compatible with C<dt_type> in the L<MongoDB>
 driver.
 
 Other acceptable values are L<BSON::Time> (explicitly), L<DateTime>,
-L<Time::Moment>, L<DateTime::Tiny>.
+L<Time::Moment>, L<DateTime::Tiny>, L<Mango::BSON::Time>.
 
 Because BSON::Time objects have methods to convert to DateTime,
 Time::Moment or DateTime::Tiny, use of this field is discouraged.  Users
@@ -729,6 +729,7 @@ type deserializes to.  Footnotes indicate variations or special behaviors.
     DateTime
     DateTime::Tiny
     Time::Moment
+    Mango::BSON::Time
     -------------------------------------------------------------------
     undef                       0x0a NULL           undef
     -------------------------------------------------------------------

--- a/lib/BSON/PP.pm
+++ b/lib/BSON/PP.pm
@@ -281,6 +281,9 @@ sub _encode_bson {
                 );
                 $bson .= pack( BSON_TYPE_NAME, 0x09, $utf8_key ) . _pack_int64( $epoch * 1000 );
             }
+            elsif ( $type eq 'Mango::BSON::Time' ) {
+                $bson .= pack( BSON_TYPE_NAME, 0x09, $utf8_key ) . _pack_int64( $value->{time} );
+            }
 
             # Timestamp
             elsif ( $type eq 'BSON::Timestamp' ) {
@@ -625,12 +628,14 @@ sub _decode_bson {
                 $value = _int64_to_bigint($value);
             }
             $value = BSON::Time->new( value => $value );
-            if ( defined $opt->{dt_type} && $opt->{dt_type} ne 'BSON::Time' ) {
+            my $dt_type = $opt->{dt_type};
+            if ( defined $dt_type && $dt_type ne 'BSON::Time' ) {
                 $value =
-                    $opt->{dt_type} eq 'Time::Moment'   ? $value->as_time_moment
-                  : $opt->{dt_type} eq 'DateTime'       ? $value->as_datetime
-                  : $opt->{dt_type} eq 'DateTime::Tiny' ? $value->as_datetime_tiny
-                  :   croak("Unsupported dt_type '$opt->{dt_type}'");
+                    $dt_type eq 'Time::Moment'      ? $value->as_time_moment
+                  : $dt_type eq 'DateTime'          ? $value->as_datetime
+                  : $dt_type eq 'DateTime::Tiny'    ? $value->as_datetime_tiny
+                  : $dt_type eq 'Mango::BSON::Time' ? $value->as_mango_time
+                  :   croak("Unsupported dt_type '$dt_type'");
             }
         }
 

--- a/lib/BSON/Time.pm
+++ b/lib/BSON/Time.pm
@@ -126,6 +126,18 @@ sub as_datetime_tiny {
     );
 }
 
+=method as_mango_time
+
+Loads L<Mango::BSON::Time> and returns the C<value> as a L<Mango::BSON::Time>
+object.
+
+=cut
+
+sub as_mango_time {
+    require Mango::BSON::Time;
+    return Mango::BSON::Time->new( $_[0]->{value} );
+}
+
 =method as_time_moment
 
 Loads L<Time::Moment> and returns the C<value> as a L<Time::Moment> object.

--- a/t/mapping/time.t
+++ b/t/mapping/time.t
@@ -48,7 +48,7 @@ SKIP: {
     # conversion
     my $obj = $hash->{A}->as_datetime;
     isa_ok( $obj, 'DateTime', 'as_datetime' );
-    is($obj->epoch, $now, "epoch"); 
+    is($obj->epoch, $now, "epoch");
 }
 
 # DateTime::Tiny -> BSON::Time
@@ -70,7 +70,7 @@ SKIP: {
     # conversion
     my $obj = $hash->{A}->as_datetime_tiny;
     isa_ok( $obj, 'DateTime::Tiny', 'as_datetime_tiny' );
-    is($obj->as_string . "Z", $hash->{A}->as_iso8601, "iso8601"); 
+    is($obj->as_string . "Z", $hash->{A}->as_iso8601, "iso8601");
 }
 
 # Time::Moment -> BSON::Time
@@ -87,7 +87,24 @@ SKIP: {
     # conversion
     my $obj = $hash->{A}->as_time_moment;
     isa_ok( $obj, 'Time::Moment', 'as_time_moment' );
-    is($obj->epoch, $now, "epoch"); 
+    is($obj->epoch, $now, "epoch");
+}
+
+# Mango::BSON::Time -> BSON::Time
+SKIP: {
+    eval { require Mango::BSON::Time };
+    skip( "Mango::BSON::Time not installed", 1 )
+      unless $INC{'Mango/BSON/Time.pm'};
+    $bson = encode( { A => Mango::BSON::Time->new( $now * 1000 ) } );
+    $hash = decode($bson);
+    is( ref( $hash->{A} ), 'BSON::Time', "Mango::BSON::Time->BSON::Time" );
+    is( "$hash->{A}",      $now,         "value correct" );
+    is( $bson,             $expect,      "BSON correct" );
+
+    # conversion
+    my $obj = $hash->{A}->as_mango_time;
+    isa_ok( $obj, 'Mango::BSON::Time', 'as_mango_time' );
+    is( $obj->to_epoch, $now, "to_epoch" );
 }
 
 # to JSON

--- a/t/options.t
+++ b/t/options.t
@@ -172,6 +172,18 @@ subtest "dt_type" => sub {
         is( ref( $hash->{A} ), 'Time::Moment', "dt_type = Time::Moment" );
     }
 
+    # Mango::BSON::Time
+    SKIP: {
+        eval { require Mango::BSON::Time };
+        skip( "Mango::BSON::Time not installed", 1 )
+        unless $INC{'Mango/BSON/Time.pm'};
+
+        my $obj = _BSON( dt_type => "Mango::BSON::Time" );
+        my $bson = $obj->encode_one( { A => bson_time() } );
+        my $hash = $obj->decode_one($bson);
+        is( ref( $hash->{A} ), 'Mango::BSON::Time', "dt_type = Mango::BSON::Time" );
+    }
+
     # unknown
     {
         my $obj = _BSON( dt_type => 'BOGUS' );


### PR DESCRIPTION
This commit adds support for the Mongo::BSON::Time type, which
will significantly simplify the transition from Mango::BSON to
MongoDB's BSON.