### PR TITLE
PERL-738 regression testing

### DIFF
--- a/t/regression/boolean_copy.t
+++ b/t/regression/boolean_copy.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+use lib 't/lib';
+use lib 't/pvtlib';
+use CleanEnv;
+
+use BSON;
+use boolean;
+
+my $c = BSON->new;
+
+# PERL-575 boolean values were references to each other, so if two were created
+# identically, then changing one would change the other.
+
+my $a = { "okay" => false, "name" => "fred0" };
+my $b = { "okay" => false, "name" => "fred1" };
+
+my $a_bin = $c->encode_one( $a );
+my $b_bin = $c->encode_one( $b );
+
+my @docs = ( map{ $c->decode_one( $_ ) } ( $a_bin, $b_bin ) );
+
+is( exception { $_->{okay} = $_->{okay}->TO_JSON for @docs },
+  undef, "replacing one boolean doesn't affect another" );
+
+done_testing;

--- a/t/regression/scalar_ref_value.t
+++ b/t/regression/scalar_ref_value.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Fatal;
+use lib 't/lib';
+use lib 't/pvtlib';
+use CleanEnv;
+
+use BSON;
+use boolean;
+
+my $c = BSON->new;
+
+# PERL-489 Providing a reference to a scalar was giving the memory reference not
+# the scalar
+
+my $value = 42.2;
+$value = "hello";
+
+is(
+    exception { $c->encode_one( { value => \$value } ) },
+    undef,
+    "encoding ref to PVNV is not fatal",
+);
+
+done_testing;

--- a/t/regression/undef_round_trip.t
+++ b/t/regression/undef_round_trip.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Test::More;
+use lib 't/lib';
+use lib 't/pvtlib';
+use CleanEnv;
+
+use BSON;
+use Tie::IxHash;
+
+my $c = BSON->new;
+
+# PERL-543 deflation to BSON then back (via database?) caused undef to be an empty string
+
+subtest 'tied Tie::IxHash' => sub {
+  my %h;
+  tie( %h, 'Tie::IxHash', h => undef );
+
+  my $bin = $c->encode_one( \%h );
+  my $doc = $c->decode_one( $bin );
+
+  is $doc->{h}, undef, 'round trip undef';
+};
+
+subtest 'OO Tie::IxHash' => sub {
+  my $h = Tie::IxHash->new( h => undef );
+
+  my $bin = $c->encode_one( $h );
+  my $doc = $c->decode_one( $bin );
+
+  is $doc->{h}, undef, 'round trip undef';
+};
+
+subtest 'standard hash' => sub {
+  my %doc = ( h => undef );
+
+  my $bin = $c->encode_one( \%doc );
+  my $doc = $c->decode_one( $bin );
+
+  is $doc->{h}, undef, 'round trip undef';
+};
+
+done_testing;


### PR DESCRIPTION
Contains tests based on the original tests from `t/bson.t` in MongoDB Perl Driver.

All tests have been placed in `t/regression` - none of the other folders made sense to store these tests.

Only issue I can possibly see is that the round-trips used do not go via a MongoDB instance - whether this actually is required is unknown at this point. May also be worth double checking the exact binary that the values are encoded to in certain tests.