### PR TITLE
PERL-1009 - Fix datetime rounding issue for blead with uselongdoubles

### DIFF
--- a/lib/BSON.pm
+++ b/lib/BSON.pm
@@ -921,7 +921,7 @@ sub _iso8601_to_epochms {
         my $frac = $s - int($s);
         my $epoch = Time::Local::timegm(int($s), $m, $h, $D, $M, $Y) - $zone_offset;
         $epoch = HAS_INT64 ? 1000 * $epoch : Math::BigInt->new($epoch) * 1000;
-        $epoch += int($frac * 1000);
+        $epoch += HAS_INT64 ? $frac * 1000 : Math::BigFloat->new($frac) * 1000;
         return $epoch;
     }
     else {

--- a/t/raw.t
+++ b/t/raw.t
@@ -4,13 +4,13 @@ use warnings;
 
 use Test::More 0.96;
 use Math::BigInt;
-use JSON::MaybeXS;
 
 use lib 't/lib';
 use lib 't/pvtlib';
 use CleanEnv;
 use TestUtils;
 use Tie::IxHash;
+use JSON::MaybeXS;
 
 use BSON qw/encode decode/;
 use BSON::Raw;


### PR DESCRIPTION
This fixes the datetime issue on blead when `uselongdoubles` is enabled. It replaces a direct rounding of  the fraction in the epoch parsing code with `Math::BigFloat` when not available.

Since the affected code was adjusted to fix the 32bit issues, I ran tests to verify permutations of 32/64 bit, `uselongdoubles` enabled and disabled, on blead and on stable.